### PR TITLE
fix: Typo in category name

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -9,7 +9,7 @@
   "editor": "Marc POLYCARPE",
   "vendor_link": "https://www.saurclient.fr/",
   "categories": [
-    "Energy"
+    "energy"
   ],
   "fields": {
     "login": {


### PR DESCRIPTION
Categories are written in lowercase.

To me, this shows the need for a validator of konnector manifest. I would love to have some help on [repo-doctor](https://github.com/cozy/cozy-libs/tree/master/packages/repo-doctor) for this purpose.